### PR TITLE
made collapser unselectable to avoid copy/pasting them

### DIFF
--- a/WebContent/jsonview.css
+++ b/WebContent/jsonview.css
@@ -58,4 +58,9 @@ body {
 .collapser {
   padding-right: 10px;
   padding-left: 6px;
+  user-select: none;
+  -o-user-select: none;
+  -moz-user-select: none;
+  -khtml-user-select: none;
+  -webkit-user-select: none;
 }


### PR DESCRIPTION
using css only (user-selected:none), tested OK on chrome.

// Je te l'avais suggéré il y a longtemps, ce coup-ci je te file tout ;)
