### PR TITLE
relative links clickable and query String appendable

### DIFF
--- a/WebContent/background.js
+++ b/WebContent/background.js
@@ -97,7 +97,8 @@ function init() {
 				workerFormatter.addEventListener("message", onWorkerFormatterMessage, false);
 				workerFormatter.postMessage({
 					json : json,
-					fnName : msg.fnName
+					fnName : msg.fnName,
+                                        queryString : msg.queryString
 				});
 			}
 		});

--- a/WebContent/content.js
+++ b/WebContent/content.js
@@ -1,5 +1,7 @@
 var port = chrome.extension.connect(), collapsers, options, jsonObject;
 
+var queryString = document.location.search;
+
 function displayError(error, loc, offset) {
 	var link = document.createElement("link"), pre = document.body.firstChild.firstChild, text = pre.textContent.substring(offset), start = 0, ranges = [], idx = 0, end, range = document
 			.createRange(), imgError = document.createElement("img"), content = document.createElement("div"), errorPosition = document.createElement("span"), container = document
@@ -122,7 +124,8 @@ function processData(data) {
 			jsonToHTML : true,
 			json : jsonText,
 			fnName : fnName,
-			offset : offset
+			offset : offset,
+                        queryString : queryString
 		});
 		try {
 			jsonObject = JSON.parse(jsonText);
@@ -254,6 +257,9 @@ function init(data) {
 	port.onMessage.addListener(function(msg) {
 		if (msg.oninit) {
 			options = msg.options;
+
+                        queryString = options.appendQs ? queryString : '';
+
 			processData(data);
 		}
 		if (msg.onjsonToHTML)

--- a/WebContent/manifest.json
+++ b/WebContent/manifest.json
@@ -4,7 +4,7 @@
 	"16": "jsonview16.png",
 	"48": "jsonview48.png",
     "128": "jsonview128.png"},
-  "version": "0.0.32",
+  "version": "0.0.33",
   "description": "Validate and view JSON documents",
   "options_page": "options.html",
   "background" : {

--- a/WebContent/options.html
+++ b/WebContent/options.html
@@ -26,6 +26,12 @@
 				<label for="openStyleInput">Build custom theme with style editor</label>
 				<button id="open-editor">Open</button>
 			</div>
+                        <hr/>
+                        <b>Links</b>
+			<div class="optionBlock">
+				<label for="appendQsInput">Append Query string to links</label>
+				<input type="checkbox" id="appendQsInput">
+			</div>
 			<p>(*) safe method forces the browser to send an extra HTTP request to get the raw HTTP content.</p>
 		</div>
 	</div>

--- a/WebContent/options.js
+++ b/WebContent/options.js
@@ -1,9 +1,10 @@
 function initOptions() {
 	var bgPage = chrome.extension.getBackgroundPage(), options = localStorage.options ? JSON.parse(localStorage.options) : {};
-	var safeMethodInput = document.getElementById("safeMethodInput"), injectInFrameInput = document.getElementById("injectInFrameInput"), addContextMenuInput = document.getElementById("addContextMenuInput");
+	var safeMethodInput = document.getElementById("safeMethodInput"), injectInFrameInput = document.getElementById("injectInFrameInput"), addContextMenuInput = document.getElementById("addContextMenuInput"), appendQsInput = document.getElementById("appendQsInput");
 	safeMethodInput.checked = options.safeMethod;
 	injectInFrameInput.checked = options.injectInFrame;
 	addContextMenuInput.checked = options.addContextMenu;
+	appendQsInput.checked = options.appendQs;
 	safeMethodInput.addEventListener("change", function() {
 		options.safeMethod = safeMethodInput.checked;
 		localStorage.options = JSON.stringify(options);
@@ -17,6 +18,12 @@ function initOptions() {
 		localStorage.options = JSON.stringify(options);
 		bgPage.refreshMenuEntry();
 	});
+
+	appendQsInput.addEventListener("change", function() {
+		options.appendQs = appendQsInput.checked;
+		localStorage.options = JSON.stringify(options);
+	});
+
 	document.getElementById("open-editor").addEventListener("click", function() {
 		location.href = "csseditor.html";
 	}, false);

--- a/WebContent/workerFormatter.js
+++ b/WebContent/workerFormatter.js
@@ -4,6 +4,8 @@
  * Original author: Benjamin Hollis
  */
 
+ var queryString = '';
+
 function htmlEncode(t) {
 	return t != null ? t.toString().replace(/&/g, "&amp;").replace(/"/g, "&quot;").replace(/</g, "&lt;").replace(/>/g, "&gt;") : '';
 }
@@ -23,10 +25,15 @@ function valueToHTML(value) {
 	else if (valueType == "number")
 		output += decorateWithSpan(value, "type-number");
 	else if (valueType == "string")
-		if (/^(http|https):\/\/[^\s]+$/.test(value))
-			output += decorateWithSpan('"', "type-string") + '<a href="' + value + '">' + htmlEncode(value) + '</a>' + decorateWithSpan('"', "type-string");
-		else
+                if( /^(http:\/|https:\/)?(\/[^\s"'<>]+)+\/?$/.test(value)) {
+                        // if we have a query string and there is already a query string in the link, do not append
+                        if(queryString != '' && /\?/.test(value)) {
+                            queryString = ''
+                        }
+			output += decorateWithSpan('"', "type-string") + '<a href="' + value + queryString + '">' + htmlEncode(value) + '</a>' + decorateWithSpan('"', "type-string")
+                } else {
 			output += decorateWithSpan('"' + value + '"', "type-string");
+                }
 	else if (valueType == "boolean")
 		output += decorateWithSpan(value, "type-boolean");
 
@@ -81,6 +88,7 @@ function jsonToHTML(json, fnName) {
 
 addEventListener("message", function(event) {
 	var object;
+        queryString = event.data.queryString;
 	try {
 		object = JSON.parse(event.data.json);
 	} catch (e) {


### PR DESCRIPTION
Added a new option to append query string to links

Hello Gildas, I added an checkbox in the options so the queryString from the URL is appended to the links.

I also made the relative links clickable because we always needed to copy and paste the path after the hostname which was very annoying to us.

I'm not sure this could be helpful for everyone but anyways, I thought that you could be interested in this change. Also im not sure if I done it the proper way, its the first time I play with chrome extensions

thank you
