### PR TITLE
Properly sanitize links to prevent HTML injection.

### DIFF
--- a/WebContent/content.js
+++ b/WebContent/content.js
@@ -45,6 +45,9 @@ function displayUI(theme, html) {
 	content += "<style>" + theme + "</style>";
 	content += html;
 	document.body.innerHTML = content;
+	document.body.querySelectorAll("a").forEach(function(a) {
+		a.setAttribute('href', atob(a.getAttribute('href')));
+	});
 	collapsers = document.querySelectorAll("#json .collapsible .collapsible");
 	statusElement = document.createElement("div");
 	statusElement.className = "status";
@@ -114,10 +117,10 @@ function extractData(rawText) {
 
 function processData(data) {
 	var xhr, jsonText;
-	
+
 	function formatToHTML(fnName, offset) {
 		if (!jsonText)
-			return;	
+			return;
 		port.postMessage({
 			jsonToHTML : true,
 			json : jsonText,

--- a/WebContent/workerFormatter.js
+++ b/WebContent/workerFormatter.js
@@ -1,6 +1,6 @@
 /**
- * Adapted the code in to order to run in a web worker. 
- * 
+ * Adapted the code in to order to run in a web worker.
+ *
  * Original author: Benjamin Hollis
  */
 
@@ -24,7 +24,7 @@ function valueToHTML(value) {
 		output += decorateWithSpan(value, "type-number");
 	else if (valueType == "string")
 		if (/^(http|https):\/\/[^\s]+$/.test(value))
-			output += decorateWithSpan('"', "type-string") + '<a href="' + value + '">' + htmlEncode(value) + '</a>' + decorateWithSpan('"', "type-string");
+			output += decorateWithSpan('"', "type-string") + '<a href="' + btoa(value) + '">' + htmlEncode(value) + '</a>' + decorateWithSpan('"', "type-string");
 		else
 			output += decorateWithSpan('"' + value + '"', "type-string");
 	else if (valueType == "boolean")


### PR DESCRIPTION
This extension allows for XSS:

```
{ "a": "http://\"><iframe/src='javascript:alert(document.domain)'></iframe>" }
```

This patch prevents the problem by base64 encoding URLs, and then decoding them in content and setting them manually with Javascript, avoiding troublesome string concatenation.
